### PR TITLE
Initial Craft 4 port.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+* Initial Craft 4 support
+
 ## 1.0.3 - 2018-05-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <p align="left"><a href="https://github.com/fruitstudios/craft-validateit" target="_blank"><img width="100" height="100" src="resources/img/validateit.svg" alt="Validateit"></a></p>
 
-# Validateit plugin for Craft 3
+# Validateit plugin for Craft 4
 
 Supercharged text field validation...
 
 ### Requirements
 
-This plugin requires Craft CMS 3.0.0 or later.
+This plugin requires Craft CMS 4.0.0 or later.
 
 ### Installation
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "fruitstudios/validateit",
     "description": "Supercharged text field validation.",
     "type": "craft-plugin",
-    "version": "1.0.3",
+    "version": "2.0.0-dev",
     "keywords": [
         "craft",
         "cms",
@@ -23,7 +23,7 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^3.0.2"
+        "craftcms/cms": "^4.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Validateit.php
+++ b/src/Validateit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Validateit plugin for Craft CMS 3.x
+ * Validateit plugin for Craft CMS 4.x
  *
  * A super simple field type which allows you toggle existing field types.
  *
@@ -43,7 +43,7 @@ class Validateit extends Plugin
     /**
      * @var string
      */
-    public $schemaVersion = '1.0.0';
+    public string $schemaVersion = '2.0.0';
 
     // Public Methods
     // =========================================================================

--- a/src/fields/ValidateitField.php
+++ b/src/fields/ValidateitField.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Validateit plugin for Craft CMS 3.x
+ * Validateit plugin for Craft CMS 4.x
  *
  * A super simple field type which allows you toggle existing field types.
  *
@@ -47,7 +47,7 @@ class ValidateitField extends Field
     // Public Methods
     // =========================================================================
 
-    public function rules()
+    public function rules(): array
     {
         $rules = parent::rules();
         $rules[] = [['type'], 'required'];
@@ -123,12 +123,12 @@ class ValidateitField extends Field
         return Schema::TYPE_TEXT;
     }
 
-    public function normalizeValue($value, ElementInterface $element = null)
+    public function normalizeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return $value;
     }
 
-    public function serializeValue($value, ElementInterface $element = null)
+    public function serializeValue(mixed $value, ?\craft\base\ElementInterface $element = null): mixed
     {
         return parent::serializeValue($value, $element);
     }
@@ -136,7 +136,7 @@ class ValidateitField extends Field
     /**
      * @inheritdoc
      */
-    public function getSettingsHtml()
+    public function getSettingsHtml(): ?string
     {
         // Render the settings template
         return Craft::$app->getView()->renderTemplate(
@@ -150,7 +150,7 @@ class ValidateitField extends Field
     /**
      * @inheritdoc
      */
-    public function getInputHtml($value, ElementInterface $element = null): string
+    public function getInputHtml(mixed $value, ?\craft\base\ElementInterface $element = null): string
     {
         // Get our id and namespace
         $id = Craft::$app->getView()->formatInputId($this->handle);

--- a/src/translations/en/validateit.php
+++ b/src/translations/en/validateit.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Validateit plugin for Craft CMS 3.x
+ * Validateit plugin for Craft CMS 4.x
  *
  * A super simple field type which allows you toggle existing field types.
  *


### PR DESCRIPTION
A basic port of Validateit to Craft 4 using the [Craft Rector](https://craftcms.com/docs/4.x/extend/updating-plugins.html#rector) rules, and bumping version numbers.

This is on use on a Craft 4 site.

I don't believe master is the correct place to PR to, but it's not clear if develop-v4 is for the unreleased version 1.0.4 or for Craft 4.